### PR TITLE
Drastic simplification of IsCached

### DIFF
--- a/backend/httpipfs/shell.go
+++ b/backend/httpipfs/shell.go
@@ -22,9 +22,7 @@ var (
 
 // IpfsStateCache contains various backend related caches
 type IpfsStateCache struct {
-	localRefs     *cache.Cache // which refs we have in local ipfs storage/cache
 	locallyCached *cache.Cache // shows if the hash and its children is locally cached by ipfs
-	refsLinks     *cache.Cache // links (children) of a parent ref/hash in ipfs
 }
 
 // Node is the struct that holds the httpipfs backend together.
@@ -106,13 +104,7 @@ func NewNode(ipfsPath, fingerprint string) (*Node, error) {
 		fingerprint: fingerprint,
 		version:     &version,
 		cache: &IpfsStateCache{
-			localRefs:     cache.New(1*time.Minute, 10*time.Minute),
 			locallyCached: cache.New(5*time.Minute, 10*time.Minute),
-			// Technically links of a ref never change once obtained
-			// This is guaranteed by ipfs content to hash scheme.
-			// But we might not need a parent ref, so it is ok
-			// to clear its links from time to time.
-			refsLinks: cache.New(7*24*time.Hour, 24*time.Hour),
 		},
 	}, nil
 }


### PR DESCRIPTION
Closes #54

The old way was to manually recreate all children refs/links of a hash.
This required several calls to IPFS via api which was not efficient,
consequently we had 3 cache structures to track it.

Now,  all of this offloaded to IPFS which as I learned can do recursive
check for children of a hash/ref in one move. The speed seems to be
about the same, but we drastically simplified the code and
get rid of *two* unnecessary caches.

We could get rid of the last cache `locallyCached` as well but it still
gives some speed advantages on consequent calls for IsCached and cache
time is only 5 minutes. Nevertheless, it is something to consider.

The most likely scenario when we need real time updates:
a user pin a file which is remote and eagerly calls `brig ls` to see
if the status changed. But if it is big file it will probably take a few
minutes anyway, so it is OK to have a bit stale info.

