### PR TITLE
Use StageFromReader instead of creation of temporary file

### DIFF
--- a/client/fs_cmds.go
+++ b/client/fs_cmds.go
@@ -146,6 +146,11 @@ func (cl *Client) StageFromReader(repoPath string, r io.Reader) error {
 	defer os.Remove(fd.Name())
 
 	if _, err := io.Copy(fd, r); err != nil {
+		fd.Close()
+		return err
+	}
+
+	if err := fd.Close(); err != nil {
 		return err
 	}
 

--- a/cmd/fs_handlers.go
+++ b/cmd/fs_handlers.go
@@ -37,22 +37,8 @@ func handleStage(ctx *cli.Context, ctl *client.Client) error {
 	}
 
 	if readFromStdin {
-		tmpFd, err := ioutil.TempFile("", "-brig.stdin.buffer")
-		if err != nil {
-			return err
-		}
-
-		if _, err := io.Copy(tmpFd, os.Stdin); err != nil {
-			tmpFd.Close()
-			return err
-		}
-
-		if err := tmpFd.Close(); err != nil {
-			return err
-		}
-
 		repoPath = ctx.Args().Get(0)
-		localPath = tmpFd.Name()
+		return ctl.StageFromReader(repoPath, os.Stdin) 
 	}
 
 	absLocalPath, err := filepath.Abs(localPath)


### PR DESCRIPTION
This fixes #58. Old way: to stage from stdin a temporary file was created
but this file was not removed after use. Which polluted temporary
directories with such files.

New way: directly stage from stdin stream with StageFromReader.
Oddly, this function was already existing but was not used.
