### PR TITLE
uncached files shown as broken symlinks in the fuse offline mode

### DIFF
--- a/fuse/file.go
+++ b/fuse/file.go
@@ -40,7 +40,6 @@ func (fi *File) Attr(ctx context.Context, attr *fuse.Attr) error {
 	var filePerm os.FileMode = 0640
 	attr.Mode = filePerm 
 	if fi.m.options.Offline {
-		fmt.Printf("info %v\n", info)
 		isCached, err := fi.m.fs.IsCached(fi.path)
 		if err != nil || !isCached {
 			// uncached file will be shown as symlink

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"context"
+	"fmt"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -14,7 +15,7 @@ import (
 
 var (
 	// ErrNotCached is returned in offline mode when we don't have a file
-	ErrNotCached = errors.New("content is not cached and may not download")
+	ErrNotCached = errors.New("content is not cached and need to be downloaded")
 	ErrTooManyWriters = errors.New("too many writers for the file")
 )
 
@@ -36,7 +37,18 @@ func (fi *File) Attr(ctx context.Context, attr *fuse.Attr) error {
 	}
 	debugLog("exec file attr: %v", fi.path)
 
-	attr.Mode = 0755
+	var filePerm os.FileMode = 0640
+	attr.Mode = filePerm 
+	if fi.m.options.Offline {
+		fmt.Printf("info %v\n", info)
+		isCached, err := fi.m.fs.IsCached(fi.path)
+		if err != nil || !isCached {
+			// uncached file will be shown as symlink
+			// we cannot read them in Offline mode,
+			// but we can delete such link and overwrite its content
+			attr.Mode = os.ModeSymlink | filePerm
+		}
+	}
 	if fi.hd != nil && fi.hd.writers > 0 {
 		attr.Size = uint64(len(fi.hd.data))
 	} else {
@@ -168,6 +180,16 @@ func (fi *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp 
 	return nil
 }
 
+// Readlink reads a symbolic link.
+// This call is triggered when OS tries to see where symlink points
+func (fi *File) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error) {
+	info, err := fi.m.fs.Stat(fi.path)
+	if err != nil {
+		return "/brig/backend/ipfs/", err
+	}
+	return fmt.Sprintf("/brig/backend/ipfs/%s", info.BackendHash), nil
+}
+
 // Compile time checks to see which interfaces we implement:
 // Please update this list when modifying code here.
 var _ = fs.Node(&File{})
@@ -176,6 +198,7 @@ var _ = fs.NodeGetxattrer(&File{})
 var _ = fs.NodeListxattrer(&File{})
 var _ = fs.NodeOpener(&File{})
 var _ = fs.NodeSetattrer(&File{})
+var _ = fs.NodeReadlinker(&File{})
 
 // Other interfaces are available, but currently not needed or make sense:
 // var _ = fs.NodeRenamer(&File{})

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"context"
 	"fmt"
+	log "github.com/sirupsen/logrus"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -42,8 +43,11 @@ func (fi *File) Attr(ctx context.Context, attr *fuse.Attr) error {
 	if fi.m.options.Offline {
 		isCached, err := fi.m.fs.IsCached(fi.path)
 		if err != nil || !isCached {
-			// uncached file will be shown as symlink
-			// we cannot read them in Offline mode,
+			if err != nil {
+				log.Errorf("IsCached failed for %s with error : %v", fi.path, err)
+			}
+			// Uncached file will be shown as symlink
+			// We cannot read them in Offline mode,
 			// but we can delete such link and overwrite its content
 			attr.Mode = os.ModeSymlink | filePerm
 		}


### PR DESCRIPTION
Closes #65

Additional/necessary changes

Added
func (fi *File) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error)
to resolve name of the link.

Changed default write permissions
from `rwx rwx rwx` to `rw- r-- ---`
