### PR TITLE
Fix/fuse compatibility

### DIFF
--- a/fuse/file.go
+++ b/fuse/file.go
@@ -3,12 +3,12 @@
 package fuse
 
 import (
-	"errors"
-	"os"
-	"sync"
 	"context"
+	"errors"
 	"fmt"
 	log "github.com/sirupsen/logrus"
+	"os"
+	"sync"
 
 	"bazil.org/fuse"
 	"bazil.org/fuse/fs"
@@ -17,6 +17,8 @@ import (
 var (
 	// ErrNotCached is returned in offline mode when we don't have a file
 	ErrNotCached = errors.New("content is not cached and need to be downloaded")
+
+	// ErrTooManyWriters is returned when writers counter is about to be overfilled
 	ErrTooManyWriters = errors.New("too many writers for the file")
 )
 
@@ -39,7 +41,7 @@ func (fi *File) Attr(ctx context.Context, attr *fuse.Attr) error {
 	debugLog("exec file attr: %v", fi.path)
 
 	var filePerm os.FileMode = 0640
-	attr.Mode = filePerm 
+	attr.Mode = filePerm
 	if fi.m.options.Offline {
 		isCached, err := fi.m.fs.IsCached(fi.path)
 		if err != nil || !isCached {

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -210,8 +210,43 @@ func (hd *Handle) truncate(size uint64) error {
 	return nil
 }
 
+// Checks is the handle ready for I/O or not
+func (hd *Handle) Poll(ctx context.Context, req *fuse.PollRequest, resp *fuse.PollResponse) error {
+	// Comment taken verbatim from fs/serve.go of bazil.org/fuse:
+	// Poll checks whether the handle is currently ready for I/O, and
+	// may request a wakeup when it is.
+	//
+	// Poll should always return quickly. Clients waiting for
+	// readiness can be woken up by passing the return value of
+	// PollRequest.Wakeup to fs.Server.NotifyPollWakeup or
+	// fuse.Conn.NotifyPollWakeup.
+	//
+	// To allow supporting poll for only some of your Nodes/Handles,
+	// the default behavior is to report immediate readiness. If your
+	// FS does not support polling and you want to minimize needless
+	// requests and log noise, implement NodePoller and return
+	// syscall.ENOSYS.
+	//
+	// The Go runtime uses epoll-based I/O whenever possible, even for
+	// regular files.
+
+	// Here we implement a dummy response which reports "I am ready".
+	// The access separation is handled by mutex, so go-rutines
+	// will have to be blocked but its ok. We do not expect many
+	// processes working with the same file
+
+	// default always ready mask
+	resp.REvents = fuse.DefaultPollMask
+
+	// We also return ENOSYS error, which sort of invalidate our response,
+	// the ENOSYS indicates that this call is not supported
+	return syscall.ENOSYS
+}
+
+
 // Compiler checks to see if we got all the interfaces right:
 var _ = fs.HandleFlusher(&Handle{})
 var _ = fs.HandleReader(&Handle{})
 var _ = fs.HandleReleaser(&Handle{})
 var _ = fs.HandleWriter(&Handle{})
+var _ = fs.HandlePoller(&Handle{})

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -175,6 +175,11 @@ func (hd *Handle) Release(ctx context.Context, req *fuse.ReleaseRequest) error {
 		return nil
 	}
 
+	err := hd.flush()
+	if err != nil {
+		return errorize("handle-release", err)
+	}
+
 	hd.mu.Lock()
 	defer hd.mu.Unlock()
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/sahib/brig
 go 1.15
 
 require (
-	bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
+	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05
 	github.com/AndreasBriese/bbloom v0.0.0-20180913140656-343706a395b7 // indirect
 	github.com/NYTimes/gziphandler v1.1.0
 	github.com/VividCortex/ewma v1.1.1 // indirect


### PR DESCRIPTION
Fixes #73 

This change make us compatible with basil/fuse versions
starting from v0.0.0-20200419173433-3ba628eaf417 where poll(2)
capabilities were introduced. Consequently, we need fuse of this
version and above (tested with up to v0.0.0-20200524192727-fb710f7dfd05)

Our fuse implementation does not support polling. So we have to
always report that poll event is ready. The rest is controlled by inner mutex.
But we also send syscall.ENOSYS which tells OS to not bother
polling since we do not support it anyway.

Additional change, improvement of fuse stability by always flushing before closing
a file.

