### PR TITLE
Fix/build adjustment for obsolete toolchains

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,7 +38,6 @@ tasks:
       - ./gateway/static/**/**/**/**
 
   build:
-    deps: [generate]
     desc: "Build the brig binary"
     cmds:
       - ./scripts/build.sh
@@ -47,6 +46,10 @@ tasks:
       - go.mod
       - ./*.go
       - ./**/*.go
+
+  dev-build:
+    deps: [generate, build]
+    desc: "Developer build from scratch (regenerates internal resources)"
 
   test:
     desc: "Run integration & unit tests"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,7 @@ tasks:
       - ./gateway/static/**/**/**/**
 
   build:
+    deps: [generate]
     desc: "Build the brig binary"
     cmds:
       - ./scripts/build.sh
@@ -46,10 +47,6 @@ tasks:
       - go.mod
       - ./*.go
       - ./**/*.go
-
-  dev-build:
-    deps: [generate, build]
-    desc: "Developer build from scratch (regenerates internal resources)"
 
   test:
     desc: "Run integration & unit tests"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # Collect some basic info about the repo state:
 BUILD_TIME="$(date --iso-8601=seconds)"
 GIT_REVISION="$(git rev-parse HEAD)"
-CURRENT_BRANCH="$(git branch --show-current)"
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 
 VERSION_PACKAGE='github.com/sahib/brig/version'
 

--- a/scripts/generate.sh
+++ b/scripts/generate.sh
@@ -16,13 +16,16 @@ go mod download
 
 INCLUDE_PATH="$(go list -f '{{ .Dir }}' zombiezen.com/go/capnproto2)"
 
+command -v capnp > /dev/null && \
 for capnp_path in "${capnp_paths[@]}"
 do
     echo "-- Generating ${capnp_path}"
     capnp compile \
         -I"${INCLUDE_PATH}/std" \
         -ogo "${capnp_path}"
-done
+done \
+|| echo "Missing 'capnp' command, the build could be incomplete"
 
 
-go generate ./...
+command -v parcello > /dev/null && \
+go generate ./... || echo "Missing 'parcello' command, the build could be incomplete"


### PR DESCRIPTION
This will help to build `brig` to those of us who runs obsolete (stable) tool chains. Here I refer to Debian stable (buster) which has quite stale git and capnp.

Changes:
- build works with older version of git
- if capnp and similar resources do not need to be regenerated (cloned directly from our repo), skip `generate` step

