### PR TITLE
Feature/fuse improvements

### DIFF
--- a/catfs/mio/overlay/overlay.go
+++ b/catfs/mio/overlay/overlay.go
@@ -342,6 +342,11 @@ func (l *Layer) Seek(offset int64, whence int) (int64, error) {
 		l.limit = newPos
 	}
 
+	if l.pos == newPos {
+		// very likely it sequent read/write request
+		// no need to seek since we already pointing to the right position
+		return l.pos, nil
+	}
 	l.pos = newPos
 
 	// Silence EOF:

--- a/catfs/mio/overlay/overlay.go
+++ b/catfs/mio/overlay/overlay.go
@@ -228,6 +228,24 @@ func (l *Layer) Write(buf []byte) (int, error) {
 	return len(buf), nil
 }
 
+// Writes data from `buf` at offset `off` counted from the start (0 offset).
+// Mimics `WriteAt` from `io` package https://golang.org/pkg/io/#WriterAt
+func (l *Layer) WriteAt(buf []byte, off int64) (n int, err error) {
+	// Copy the buffer, since we cannot rely on it being valid forever.
+	modBuf := make([]byte, len(buf))
+	copy(modBuf, buf)
+
+	l.index.Add(&Modification{off, modBuf})
+	end := off + int64(len(buf))
+	if l.limit >= 0 && end > l.limit {
+		l.limit = end
+	}
+
+	n = len(buf)
+	err = nil
+	return n, nil
+}
+
 // hasGaps checks if overlays occludes all bytes between `start` and `end`
 func hasGaps(overlays []Interval, start, end int64) bool {
 	diff := end - start

--- a/fuse/directory.go
+++ b/fuse/directory.go
@@ -202,7 +202,10 @@ func (dir *Directory) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, r
 	defer logPanic("dir: getxattr")
 
 	debugLog("exec dir getxattr: %v: %v", dir.path, req.Name)
-	xattrs, err := getXattr(dir.m.fs, req.Name, dir.path, req.Size)
+
+	// Do not worry about req.Size
+	// fuse will cut it to allowed size and report to the caller that buffer need to be larger
+	xattrs, err := getXattr(dir.m.fs, req.Name, dir.path)
 	if err != nil {
 		return err
 	}

--- a/fuse/directory.go
+++ b/fuse/directory.go
@@ -211,12 +211,14 @@ func (dir *Directory) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, r
 	return nil
 }
 
-// Listxattr is called to list all xattrs of this file.
+// Listxattr is called to list all xattrs of this dir
 func (dir *Directory) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
 	defer logPanic("dir: listxattr")
 
 	debugLog("exec dir listxattr")
-	resp.Xattr = listXattr(req.Size)
+	// Do not worry about req.Size
+	// fuse will cut it to allowed size and report to the caller that buffer need to be larger
+	resp.Xattr = listXattr()
 	return nil
 }
 

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -164,7 +164,9 @@ func (fi *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp 
 	defer logPanic("file: listxattr")
 	log.Debugf("fuse-file-listxattr: %v", fi.path)
 
-	resp.Xattr = listXattr(req.Size)
+	// Do not worry about req.Size
+	// fuse will cut it to allowed size and report to the caller that buffer need to be larger
+	resp.Xattr = listXattr()
 	return nil
 }
 

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -165,7 +165,7 @@ func (fi *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 
 // Getxattr is called to get a single xattr (extended attribute) of a file.
 func (fi *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	// defer logPanic("file: getxattr")
+	defer logPanic("file: getxattr")
 	// log.Debugf("fuse-file-getxattr %v for atribute %v", fi.path, req.Name)
 
 	// debugLog("exec file getxattr: %v: %v", fi.path, req.Name)

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -150,7 +150,10 @@ func (fi *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *f
 	// log.Debugf("fuse-file-getxattr %v for atribute %v", fi.path, req.Name)
 
 	// debugLog("exec file getxattr: %v: %v", fi.path, req.Name)
-	xattrs, err := getXattr(fi.m.fs, req.Name, fi.path, req.Size)
+
+	// Do not worry about req.Size
+	// fuse will cut it to allowed size and report to the caller that buffer need to be larger
+	xattrs, err := getXattr(fi.m.fs, req.Name, fi.path)
 	if err != nil {
 		return err
 	}

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -113,6 +113,7 @@ func (fi *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.Open
 	if req.Flags.IsReadOnly() {
 		// we don't need to track read-only handles
 		// and no need to set handle `data`
+		resp.Flags |= fuse.OpenKeepCache
 		return fi.hd, nil
 	}
 
@@ -129,6 +130,7 @@ func (fi *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.Open
 		return nil, errorize(fi.path, ErrTooManyWriters)
 	}
 	fi.hd.writers++
+	resp.Flags |= fuse.OpenKeepCache
 	return fi.hd, nil
 }
 

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -34,6 +34,7 @@ type File struct {
 // Attr is called to get the stat(2) attributes of a file.
 func (fi *File) Attr(ctx context.Context, attr *fuse.Attr) error {
 	defer logPanic("file: attr")
+	log.Debugf("fuse-file-attr: %v", fi.path)
 
 	info, err := fi.m.fs.Stat(fi.path)
 	if err != nil {
@@ -83,6 +84,7 @@ func (fi *File) Attr(ctx context.Context, attr *fuse.Attr) error {
 func (fi *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenResponse) (fs.Handle, error) {
 	defer logPanic("file: open")
 	debugLog("fuse-open: %s", fi.path)
+	log.Debugf("fuse-file-open: %v with request %v", fi.path, req)
 
 	// Check if the file is actually available locally.
 	if fi.m.options.Offline {
@@ -135,11 +137,11 @@ func (fi *File) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.Open
 // file, the size change is noticed here before Open() is called.
 func (fi *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fuse.SetattrResponse) error {
 	defer logPanic("file: setattr")
+	log.Debugf("fuse-file-setattr: request %v", req)
 
 	// This is called when any attribute of the file changes,
 	// most importantly the file size. For example it is called when truncating
 	// the file to zero bytes with a size change of `0`.
-	debugLog("exec file setattr")
 	switch {
 	case req.Valid&fuse.SetattrSize != 0:
 		if err := fi.hd.truncate(req.Size); err != nil {
@@ -158,8 +160,8 @@ func (fi *File) Setattr(ctx context.Context, req *fuse.SetattrRequest, resp *fus
 // Currently, fsync is completely ignored.
 func (fi *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 	defer logPanic("file: fsync")
+	log.Debugf("fuse-file-fsync: %v", fi.path)
 
-	debugLog("exec file fsync")
 	return nil
 }
 
@@ -181,8 +183,8 @@ func (fi *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *f
 // Listxattr is called to list all xattrs of this file.
 func (fi *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
 	defer logPanic("file: listxattr")
+	log.Debugf("fuse-file-listxattr: %v", fi.path)
 
-	debugLog("exec file listxattr")
 	resp.Xattr = listXattr(req.Size)
 	return nil
 }
@@ -190,6 +192,7 @@ func (fi *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp 
 // Readlink reads a symbolic link.
 // This call is triggered when OS tries to see where symlink points
 func (fi *File) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error) {
+	log.Debugf("fuse-file-readlink: %v", fi.path)
 	info, err := fi.m.fs.Stat(fi.path)
 	if err != nil {
 		return "/brig/backend/ipfs/", err

--- a/fuse/file.go
+++ b/fuse/file.go
@@ -165,9 +165,10 @@ func (fi *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) error {
 
 // Getxattr is called to get a single xattr (extended attribute) of a file.
 func (fi *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	defer logPanic("file: getxattr")
+	// defer logPanic("file: getxattr")
+	// log.Debugf("fuse-file-getxattr %v for atribute %v", fi.path, req.Name)
 
-	debugLog("exec file getxattr: %v: %v", fi.path, req.Name)
+	// debugLog("exec file getxattr: %v: %v", fi.path, req.Name)
 	xattrs, err := getXattr(fi.m.fs, req.Name, fi.path, req.Size)
 	if err != nil {
 		return err

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -71,7 +71,7 @@ func (hd *Handle) loadData(path string) error {
 func (hd *Handle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
 	hd.mu.Lock()
 	defer hd.mu.Unlock()
-	// defer logPanic("handle: read")
+	defer logPanic("handle: read")
 
 	// log.WithFields(log.Fields{
 	// "path":   hd.fd.Path(),

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -61,8 +61,6 @@ func (hd *Handle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.Re
 	return nil
 }
 
-const maxInt = int(^uint(0) >> 1)
-
 // Write is called to write a block of data at a certain offset.
 // Note: do not assume that Write requests come in `fifo` order from the OS level!!!
 // I.e. during `cp largeFile /brig-fuse-mount/newFile`

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -71,7 +71,7 @@ func (hd *Handle) loadData(path string) error {
 func (hd *Handle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
 	hd.mu.Lock()
 	defer hd.mu.Unlock()
-	defer logPanic("handle: read")
+	// defer logPanic("handle: read")
 
 	// log.WithFields(log.Fields{
 	// "path":   hd.fd.Path(),

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -64,10 +64,12 @@ func (hd *Handle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.Re
 const maxInt = int(^uint(0) >> 1)
 
 // Write is called to write a block of data at a certain offset.
+// Note: do not assume that Write requests come in `fifo` order from the OS level!!!
+// I.e. during `cp largeFile /brig-fuse-mount/newFile`
+// the kernel might occasionally send write requests with blocks out of order!!!
+// In other words stream-like optimizations are not possible .
 func (hd *Handle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error {
 	start := time.Now()
-	// Note: even when underlying process makes consequent writes,
-	// the kernel might send blocks out of order!!!
 	hd.mu.Lock()
 	defer hd.mu.Unlock()
 	defer logPanic("handle: write")

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -75,11 +75,12 @@ func (hd *Handle) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.Re
 	defer hd.mu.Unlock()
 	defer logPanic("handle: read")
 
-	// log.WithFields(log.Fields{
-	// "path":   hd.fd.Path(),
-	// "offset": req.Offset,
-	// "size":   req.Size,
-	// }).Debugf("fuse: handle: read")
+	log.Debugf(
+		"fuse-Read: %s (off: %d size: %d)",
+		hd.fd.Path(),
+		req.Offset,
+		req.Size,
+	)
 
 	// if we have writers we can supply response from the write data buffer
 	if hd.writers != 0 {
@@ -120,7 +121,7 @@ func (hd *Handle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.
 	defer logPanic("handle: write")
 
 	log.Debugf(
-		"fuse-write: %s (off: %d size: %d)",
+		"fuse-Write: %s (off: %d size: %d)",
 		hd.fd.Path(),
 		req.Offset,
 		len(req.Data),

--- a/fuse/handle.go
+++ b/fuse/handle.go
@@ -80,7 +80,7 @@ func (hd *Handle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.
 	)
 
 	// Offset seems to be always provided from the start (i.e. 0)
-	n, err := hd.WriteAt(req.Data, req.Offset)
+	n, err := hd.writeAt(req.Data, req.Offset)
 	resp.Size = n
 	if err != nil {
 		return errorize("handle-write-io", err)
@@ -98,7 +98,7 @@ func (hd *Handle) Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.
 // Mimics `WriteAt` from `io` package https://golang.org/pkg/io/#WriterAt
 // Main idea is not bother with Seek pointer, since underlying `overlay` works
 // with intervals in memory and we do not need to `Seek` the backend which is very time expensive.
-func (hd *Handle) WriteAt(buf []byte, off int64) (n int, err error) {
+func (hd *Handle) writeAt(buf []byte, off int64) (n int, err error) {
 	n, err = hd.fd.WriteAt(buf, off)
 	if n != len(buf) || err != nil {
 		log.Errorf("fuse: were not able to save %d bytes at offset %d", len(buf), off)

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -67,6 +67,7 @@ func NewMount(cfs *catfs.FS, mountpoint string, notifier Notifier, opts MountOpt
 		fuse.FSName("brigfs"),
 		fuse.Subtype("brig"),
 		fuse.AllowNonEmptyMount(),
+		fuse.MaxReadahead(128*1024), // kernel uses at max 128kB = 131072B
 	}
 
 	if opts.ReadOnly {

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -67,7 +67,10 @@ func NewMount(cfs *catfs.FS, mountpoint string, notifier Notifier, opts MountOpt
 		fuse.FSName("brigfs"),
 		fuse.Subtype("brig"),
 		fuse.AllowNonEmptyMount(),
+		// enabling MaxReadahead double or even triple Read throughput 12MB/s -> 25 or 33 MB/s
 		fuse.MaxReadahead(128*1024), // kernel uses at max 128kB = 131072B
+		// enabling WritebackCache doubles write speed to buffer 12MB/s -> 24MB/s
+		fuse.WritebackCache(), // writes will happen in mach large blocks 128kB instead of 8kB
 	}
 
 	if opts.ReadOnly {

--- a/fuse/mount.go
+++ b/fuse/mount.go
@@ -68,7 +68,7 @@ func NewMount(cfs *catfs.FS, mountpoint string, notifier Notifier, opts MountOpt
 		fuse.Subtype("brig"),
 		fuse.AllowNonEmptyMount(),
 		// enabling MaxReadahead double or even triple Read throughput 12MB/s -> 25 or 33 MB/s
-		fuse.MaxReadahead(128*1024), // kernel uses at max 128kB = 131072B
+		fuse.MaxReadahead(128 * 1024), // kernel uses at max 128kB = 131072B
 		// enabling WritebackCache doubles write speed to buffer 12MB/s -> 24MB/s
 		fuse.WritebackCache(), // writes will happen in mach large blocks 128kB instead of 8kB
 	}

--- a/fuse/util.go
+++ b/fuse/util.go
@@ -34,23 +34,18 @@ func logPanic(name string) {
 	}
 }
 
-func listXattr(size uint32) []byte {
+func listXattr() []byte {
 	resp := []byte{}
 	resp = append(resp, "user.brig.hash\x00"...)
 	resp = append(resp, "user.brig.content\x00"...)
 	resp = append(resp, "user.brig.pinned\x00"...)
 	resp = append(resp, "user.brig.explicitly_pinned\x00"...)
 
-	if uint32(len(resp)) > size {
-		resp = resp[:size]
-	}
-
 	return resp
 }
 
 func isKnownAttribute(name string) bool {
-	reqSize := uint32(1024)
-	knownAttrs := bytes.Split(listXattr(reqSize), []byte{0})
+	knownAttrs := bytes.Split(listXattr(), []byte{0})
 	for _, attr := range knownAttrs {
 		if string(attr) == name {
 			return true
@@ -92,11 +87,8 @@ func getXattr(cfs *catfs.FS, name, path string, size uint32) ([]byte, error) {
 		return nil, fuse.ErrNoXattr
 	}
 
-	// Truncate if less bytes were requested for some reason:
-	if uint32(len(resp)) > size {
-		resp = resp[:size]
-	}
-
+	// Do not worry about req.Size
+	// fuse will cut it to allowed size and report to the caller that buffer need to be larger
 	return resp, nil
 }
 

--- a/fuse/util.go
+++ b/fuse/util.go
@@ -51,7 +51,7 @@ func listXattr(size uint32) []byte {
 func isKnownAttribute(name string) bool {
 	reqSize := uint32(1024)
 	knownAttrs := bytes.Split(listXattr(reqSize), []byte{0})
-	for _, attr := range(knownAttrs) {
+	for _, attr := range knownAttrs {
 		if string(attr) == name {
 			return true
 		}

--- a/fuse/util.go
+++ b/fuse/util.go
@@ -3,6 +3,7 @@
 package fuse
 
 import (
+	"bytes"
 	"time"
 
 	"bazil.org/fuse"
@@ -26,7 +27,7 @@ func errorize(name string, err error) error {
 }
 
 // logPanic logs any panics by being called in a defer.
-// A rather inconvinient behaviour of fuse is to not report panics.
+// A rather inconvenient behaviour of fuse is to not report panics.
 func logPanic(name string) {
 	if err := recover(); err != nil {
 		log.Errorf("bug: %s panicked: %v", name, err)

--- a/fuse/util.go
+++ b/fuse/util.go
@@ -47,7 +47,22 @@ func listXattr(size uint32) []byte {
 	return resp
 }
 
+func isKnownAttribute(name string) bool {
+	reqSize := uint32(1024)
+	knownAttrs := bytes.Split(listXattr(reqSize), []byte{0})
+	for _, attr := range(knownAttrs) {
+		if string(attr) == name {
+			return true
+		}
+	}
+	return false
+}
+
 func getXattr(cfs *catfs.FS, name, path string, size uint32) ([]byte, error) {
+	if !isKnownAttribute(name) {
+		return nil, fuse.ErrNoXattr
+	}
+
 	info, err := cfs.Stat(path)
 	if err != nil {
 		return nil, errorize("getxattr", err)

--- a/fuse/util.go
+++ b/fuse/util.go
@@ -38,6 +38,7 @@ func listXattr(size uint32) []byte {
 	resp = append(resp, "user.brig.hash\x00"...)
 	resp = append(resp, "user.brig.content\x00"...)
 	resp = append(resp, "user.brig.pinned\x00"...)
+	resp = append(resp, "user.brig.explicitly_pinned\x00"...)
 
 	if uint32(len(resp)) > size {
 		resp = resp[:size]
@@ -65,7 +66,7 @@ func getXattr(cfs *catfs.FS, name, path string, size uint32) ([]byte, error) {
 		} else {
 			resp = []byte("no")
 		}
-	case "user.brig.explicit":
+	case "user.brig.explicitly_pinned":
 		if info.IsExplicit {
 			resp = []byte("yes")
 		} else {


### PR DESCRIPTION
Adresses #49 
Enabling `fuse` optimizations at mount: Cache and larger buffer sizes. This gives quite large speed improvements, I even had to think about disabling  debug outputs, since it takes comparable time to disk io.

Also, removed use of write buffer back to `overlay` system. 

Main slow down for using `overlay` was useless `Seek` at write: we write to memory overlay but aks the backend to `Seek` for no reason.  This problem solved with `WriteAt` method.

@sahib please pay attention how the `overlay` limits are handled. I am not sure that I fully grasped what for they are used. The structure field had no comment :(