### PR TITLE
fix: the file system `badger db` is now closed on Quit

### DIFF
--- a/repo/repo.go
+++ b/repo/repo.go
@@ -113,6 +113,11 @@ func Open(baseFolder string) (*Repository, error) {
 // Close will lock the repository, making this instance unusable.
 func (rp *Repository) Close() error {
 	rp.stopAutoGCLoop()
+	for owner, fs := range rp.fsMap {
+		log.Infof("closing FS for %s", owner)
+		fs.Close()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Somehow, we never closed FS DB on quit or interrupt. Miraculously, `brig`
worked on restart as if nothing happened. But the DB was left in a dirty
state, with DB `LOCK` file left and some other transient tables.
