### PR TITLE
cmd: allow specifiyng a ipfs-url instead of a ipfs-path (--ipfs-path-…

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -35,18 +35,6 @@ type Backend interface {
 	eventsBackend.Backend
 }
 
-// InitByName creates a new backend structure at `path` for the backend `name`
-func InitByName(name, path string, port int) error {
-	switch name {
-	case "httpipfs":
-		return httpipfs.Init(path)
-	case "mock":
-		return nil
-	}
-
-	return ErrNoSuchBackend
-}
-
 // ForwardLogByName will forward the logs of the backend `name` to `w`.
 func ForwardLogByName(name string, w io.Writer) error {
 	switch name {

--- a/backend/httpipfs/init.go
+++ b/backend/httpipfs/init.go
@@ -1,8 +1,0 @@
-package httpipfs
-
-// Init will create the folder structure for anything
-// that needs to be persisted in the repository.
-func Init(path string) error {
-	// currently we do not need to persist anything.
-	return nil
-}

--- a/backend/httpipfs/shell.go
+++ b/backend/httpipfs/shell.go
@@ -77,26 +77,26 @@ func WithNoLogging() Option {
 	}
 }
 
-func toMultiAddr(ipfsPathOrURL string) (ma.Multiaddr, error) {
-	if !filepath.IsAbs(ipfsPathOrURL) {
+func toMultiAddr(ipfsPathOrMultiaddr string) (ma.Multiaddr, error) {
+	if !filepath.IsAbs(ipfsPathOrMultiaddr) {
 		// multiaddr always start with a slash,
 		// this branch affects only file paths.
 		var err error
-		ipfsPathOrURL, err = filepath.Abs(ipfsPathOrURL)
+		ipfsPathOrMultiaddr, err = filepath.Abs(ipfsPathOrMultiaddr)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	if _, err := os.Stat(ipfsPathOrURL); err == nil {
-		return setup.GetAPIAddrForPath(ipfsPathOrURL)
+	if _, err := os.Stat(ipfsPathOrMultiaddr); err == nil {
+		return setup.GetAPIAddrForPath(ipfsPathOrMultiaddr)
 	}
 
-	return ma.NewMultiaddr(ipfsPathOrURL)
+	return ma.NewMultiaddr(ipfsPathOrMultiaddr)
 }
 
 // NewNode returns a new http based IPFS backend.
-func NewNode(ipfsPathOrURL string, fingerprint string, opts ...Option) (*Node, error) {
+func NewNode(ipfsPathOrMultiaddr string, fingerprint string, opts ...Option) (*Node, error) {
 	nd := &Node{
 		allowNetOps: true,
 		fingerprint: fingerprint,
@@ -109,7 +109,7 @@ func NewNode(ipfsPathOrURL string, fingerprint string, opts ...Option) (*Node, e
 		opt(nd)
 	}
 
-	m, err := toMultiAddr(ipfsPathOrURL)
+	m, err := toMultiAddr(ipfsPathOrMultiaddr)
 	if err != nil {
 		return nil, err
 	}

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -381,10 +381,10 @@ func newFuseWriteOrReadBench(ipfsPath string, isWrite bool) (Bench, error) {
 	unixSocket := "unix:" + filepath.Join(tmpDir, "socket")
 
 	proc, err := fusetest.LaunchAsProcess(fusetest.Options{
-		MountPath:     filepath.Join(tmpDir, "mount"),
-		CatfsPath:     filepath.Join(tmpDir, "catfs"),
-		IpfsPathOrURL: ipfsPath,
-		URL:           unixSocket,
+		MountPath:           filepath.Join(tmpDir, "mount"),
+		CatfsPath:           filepath.Join(tmpDir, "catfs"),
+		IpfsPathOrMultiaddr: ipfsPath,
+		URL:                 unixSocket,
 	})
 
 	if err != nil {

--- a/bench/bench.go
+++ b/bench/bench.go
@@ -381,10 +381,10 @@ func newFuseWriteOrReadBench(ipfsPath string, isWrite bool) (Bench, error) {
 	unixSocket := "unix:" + filepath.Join(tmpDir, "socket")
 
 	proc, err := fusetest.LaunchAsProcess(fusetest.Options{
-		MountPath: filepath.Join(tmpDir, "mount"),
-		CatfsPath: filepath.Join(tmpDir, "catfs"),
-		IpfsPath:  ipfsPath,
-		URL:       unixSocket,
+		MountPath:     filepath.Join(tmpDir, "mount"),
+		CatfsPath:     filepath.Join(tmpDir, "catfs"),
+		IpfsPathOrURL: ipfsPath,
+		URL:           unixSocket,
 	})
 
 	if err != nil {

--- a/client/clienttest/daemon.go
+++ b/client/clienttest/daemon.go
@@ -34,7 +34,11 @@ func StartDaemon(name, backendName, ipfsPath string) (*server.Server, error) {
 	}
 
 	if backendName == "httpipfs" {
-		if err := repo.OverwriteConfigKey(repoPath, "daemon.ipfs_path", ipfsPath); err != nil {
+		if err := repo.OverwriteConfigKey(
+			repoPath,
+			"daemon.ipfs_path_or_url",
+			ipfsPath,
+		); err != nil {
 			return nil, err
 		}
 	}

--- a/client/fs_cmds.go
+++ b/client/fs_cmds.go
@@ -246,13 +246,13 @@ func (cl *Client) CatOnClient(path string, offline bool, w io.Writer) error {
 		return err
 	}
 
-	ipfsPath, err := cl.ConfigGet("daemon.ipfs_path")
+	ipfsPathOrURL, err := cl.ConfigGet("daemon.ipfs_path_or_url")
 	if err != nil {
 		return err
 	}
 
-	if ipfsPath == "" {
-		return fmt.Errorf("no ipfs-path found - is this repo using IPFS?")
+	if ipfsPathOrURL == "" {
+		return fmt.Errorf("no IPFS path or URL found - is this repo using IPFS?")
 	}
 
 	if offline {
@@ -267,7 +267,7 @@ func (cl *Client) CatOnClient(path string, offline bool, w io.Writer) error {
 	}
 
 	nd, err := httpipfs.NewNode(
-		ipfsPath,
+		ipfsPathOrURL,
 		"",
 		httpipfs.WithNoLogging(),
 	)

--- a/client/fs_cmds.go
+++ b/client/fs_cmds.go
@@ -246,12 +246,12 @@ func (cl *Client) CatOnClient(path string, offline bool, w io.Writer) error {
 		return err
 	}
 
-	ipfsPathOrURL, err := cl.ConfigGet("daemon.ipfs_path_or_url")
+	ipfsPathOrMultiaddr, err := cl.ConfigGet("daemon.ipfs_path_or_url")
 	if err != nil {
 		return err
 	}
 
-	if ipfsPathOrURL == "" {
+	if ipfsPathOrMultiaddr == "" {
 		return fmt.Errorf("no IPFS path or URL found - is this repo using IPFS?")
 	}
 
@@ -267,7 +267,7 @@ func (cl *Client) CatOnClient(path string, offline bool, w io.Writer) error {
 	}
 
 	nd, err := httpipfs.NewNode(
-		ipfsPathOrURL,
+		ipfsPathOrMultiaddr,
 		"",
 		httpipfs.WithNoLogging(),
 	)

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -135,12 +135,12 @@ func handleDebugTenSink(ctx *cli.Context) error {
 
 func handleDebugFuseMock(ctx *cli.Context) error {
 	opts := fusetest.Options{
-		CatfsPath:     ctx.String("catfs-path"),
-		MountPath:     ctx.String("mount-path"),
-		IpfsPathOrURL: ctx.String("ipfs-path-or-url"),
-		URL:           ctx.String("url"),
-		MountReadOnly: ctx.Bool("mount-ro"),
-		MountOffline:  ctx.Bool("mount-offline"),
+		CatfsPath:           ctx.String("catfs-path"),
+		MountPath:           ctx.String("mount-path"),
+		IpfsPathOrMultiaddr: ctx.String("ipfs-path-or-multiaddr"),
+		URL:                 ctx.String("url"),
+		MountReadOnly:       ctx.Bool("mount-ro"),
+		MountOffline:        ctx.Bool("mount-offline"),
 	}
 
 	return fusetest.Launch(opts)

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -137,7 +137,7 @@ func handleDebugFuseMock(ctx *cli.Context) error {
 	opts := fusetest.Options{
 		CatfsPath:     ctx.String("catfs-path"),
 		MountPath:     ctx.String("mount-path"),
-		IpfsPath:      ctx.String("ipfs-path"),
+		IpfsPathOrURL: ctx.String("ipfs-path-or-url"),
 		URL:           ctx.String("url"),
 		MountReadOnly: ctx.Bool("mount-ro"),
 		MountOffline:  ctx.Bool("mount-offline"),

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -83,7 +83,7 @@ var helpTexts = map[string]helpEntry{
 			},
 			cli.StringFlag{
 				Name:  "ipfs-path-or-multiaddr",
-				Usage: "Specify an explicit path or URL to an IPFS repository. Useful if you have more than one.",
+				Usage: "Specify a path to an ipfs repo (/tmp/ipfs-repo) or a multiaddr to a running ipfs daemon (/ip4/127.0.0.1/tcp/5002)",
 				Value: "",
 			},
 			cli.BoolFlag{

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -82,7 +82,7 @@ var helpTexts = map[string]helpEntry{
 				Usage: "Do not display the super pretty logo on init.",
 			},
 			cli.StringFlag{
-				Name:  "ipfs-path-or-url",
+				Name:  "ipfs-path-or-multiaddr",
 				Usage: "Specify an explicit path or URL to an IPFS repository. Useful if you have more than one.",
 				Value: "",
 			},
@@ -1535,7 +1535,7 @@ EXAMPLES:
 				Value: "unix:/tmp/fuse-mock.socket",
 			},
 			cli.StringFlag{
-				Name:  "ipfs-path-or-url,i",
+				Name:  "ipfs-path-or-multiaddr,i",
 				Usage: "Path to IPFS, if you want to use it. Empty for memory only.",
 				Value: "",
 			},

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -82,8 +82,8 @@ var helpTexts = map[string]helpEntry{
 				Usage: "Do not display the super pretty logo on init.",
 			},
 			cli.StringFlag{
-				Name:  "ipfs-path,P",
-				Usage: "Specify an explicit path to an IPFS repository. Useful if you have more than one.",
+				Name:  "ipfs-path-or-url",
+				Usage: "Specify an explicit path or URL to an IPFS repository. Useful if you have more than one.",
 				Value: "",
 			},
 			cli.BoolFlag{
@@ -1535,7 +1535,7 @@ EXAMPLES:
 				Value: "unix:/tmp/fuse-mock.socket",
 			},
 			cli.StringFlag{
-				Name:  "ipfs-path,i",
+				Name:  "ipfs-path-or-url,i",
 				Usage: "Path to IPFS, if you want to use it. Empty for memory only.",
 				Value: "",
 			},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,63 +1,22 @@
 package cmd
 
 import (
-	"fmt"
-	"path/filepath"
-	"strconv"
-	"strings"
-
 	e "github.com/pkg/errors"
-	"github.com/sahib/brig/backend"
 	"github.com/sahib/brig/repo"
-	"github.com/sahib/brig/repo/setup"
 	"github.com/urfave/cli"
 )
 
 // Init creates a new brig repository at `basePath` with specified options.
-func Init(ctx *cli.Context, ipfsPath string, opts repo.InitOptions) error {
+func Init(ctx *cli.Context, ipfsPathOrURL string, opts repo.InitOptions) error {
 	if err := repo.Init(opts); err != nil {
 		return e.Wrapf(err, "repo-init")
 	}
 
-	apiAddr, err := setup.GetAPIAddrForPath(ipfsPath)
-	if err != nil {
-		return e.Wrapf(err, "no config - is »%s« an IPFS repo?", apiAddr)
-	}
-
-	splitAPIAddr := strings.Split(string(apiAddr), "/")
-	if len(splitAPIAddr) == 0 {
-		return fmt.Errorf(
-			"failed to read IPFS api port to connect to (at %s): %v",
-			ipfsPath,
-			err,
-		)
-	}
-
-	ipfsPort, err := strconv.Atoi(splitAPIAddr[len(splitAPIAddr)-1])
-	if err != nil {
-		return fmt.Errorf(
-			"failed to convert api port to string (at %s): %v",
-			ipfsPath,
-			err,
-		)
-	}
-
-	if err := repo.OverwriteConfigKey(
+	// Remember the ipsf connection details,
+	// so we can start it later.
+	return repo.OverwriteConfigKey(
 		opts.BaseFolder,
-		"daemon.ipfs_path",
-		ipfsPath,
-	); err != nil {
-		return err
-	}
-
-	backendPath := filepath.Join(opts.BaseFolder, "data", opts.BackendName)
-	if err := backend.InitByName(
-		opts.BackendName,
-		backendPath,
-		ipfsPort,
-	); err != nil {
-		return e.Wrapf(err, "backend-init")
-	}
-
-	return nil
+		"daemon.ipfs_path_or_url",
+		ipfsPathOrURL,
+	)
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Init creates a new brig repository at `basePath` with specified options.
-func Init(ctx *cli.Context, ipfsPathOrURL string, opts repo.InitOptions) error {
+func Init(ctx *cli.Context, ipfsPathOrMultiaddr string, opts repo.InitOptions) error {
 	if err := repo.Init(opts); err != nil {
 		return e.Wrapf(err, "repo-init")
 	}
@@ -17,6 +17,6 @@ func Init(ctx *cli.Context, ipfsPathOrURL string, opts repo.InitOptions) error {
 	return repo.OverwriteConfigKey(
 		opts.BaseFolder,
 		"daemon.ipfs_path_or_url",
-		ipfsPathOrURL,
+		ipfsPathOrMultiaddr,
 	)
 }

--- a/cmd/parser.go
+++ b/cmd/parser.go
@@ -140,7 +140,7 @@ func RunCmdline(args []string) int {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "url,u",
-			Usage:  "URL on where to reach the brig daemon. Leave empty to allow guessing.",
+			Usage:  "URL on where to reach the brig daemon.",
 			EnvVar: "BRIG_URL",
 			Value:  defaults.DaemonDefaultURL(),
 		},

--- a/cmd/repo_handlers.go
+++ b/cmd/repo_handlers.go
@@ -101,8 +101,8 @@ Have a nice day.
 	return ctl.MakeCommit("added initial README.md")
 }
 
-func isMultiAddr(ipfsPathOrURL string) bool {
-	_, err := os.Stat(ipfsPathOrURL)
+func isMultiAddr(ipfsPathOrMultiaddr string) bool {
+	_, err := os.Stat(ipfsPathOrMultiaddr)
 	return err != nil
 }
 
@@ -151,13 +151,13 @@ func handleInit(ctx *cli.Context) error {
 		return fmt.Errorf("`%s` already exists and is not empty; refusing to do init", folder)
 	}
 
-	ipfsPathOrURL := ctx.String("ipfs-path-or-url")
+	ipfsPathOrMultiaddr := ctx.String("ipfs-path-or-multiaddr")
 	doIpfsSetup := !ctx.Bool("no-ipfs-setup")
 	doIpfsConfig := !ctx.Bool("no-ipfs-config")
 	doExtraIpfsConfig := !ctx.Bool("no-ipfs-optimization")
 
-	ipfsRepoPath := ipfsPathOrURL
-	isMa := isMultiAddr(ipfsPathOrURL)
+	ipfsRepoPath := ipfsPathOrMultiaddr
+	isMa := isMultiAddr(ipfsPathOrMultiaddr)
 	if isMa {
 		// NOTE: If we're connecting over a multiaddr,
 		//       then we should not setup an ipfs repo.
@@ -185,7 +185,7 @@ func handleInit(ctx *cli.Context) error {
 
 	if err := Init(
 		ctx,
-		ipfsPathOrURL,
+		ipfsPathOrMultiaddr,
 		repo.InitOptions{
 			BaseFolder:  folder,
 			Owner:       owner,

--- a/cmd/repo_handlers.go
+++ b/cmd/repo_handlers.go
@@ -101,6 +101,11 @@ Have a nice day.
 	return ctl.MakeCommit("added initial README.md")
 }
 
+func isMultiAddr(ipfsPathOrURL string) bool {
+	_, err := os.Stat(ipfsPathOrURL)
+	return err != nil
+}
+
 func handleInit(ctx *cli.Context) error {
 	if len(ctx.Args()) == 0 {
 		return fmt.Errorf("Please specify a name for the owner of this repository")
@@ -146,10 +151,20 @@ func handleInit(ctx *cli.Context) error {
 		return fmt.Errorf("`%s` already exists and is not empty; refusing to do init", folder)
 	}
 
-	ipfsPath := ctx.String("ipfs-path")
+	ipfsPathOrURL := ctx.String("ipfs-path-or-url")
 	doIpfsSetup := !ctx.Bool("no-ipfs-setup")
 	doIpfsConfig := !ctx.Bool("no-ipfs-config")
 	doExtraIpfsConfig := !ctx.Bool("no-ipfs-optimization")
+
+	ipfsRepoPath := ipfsPathOrURL
+	isMa := isMultiAddr(ipfsPathOrURL)
+	if isMa {
+		// NOTE: If we're connecting over a multiaddr,
+		//       then we should not setup an ipfs repo.
+		//       Assumption is that it exists already.
+		doIpfsSetup = false
+		ipfsRepoPath = ""
+	}
 
 	if backend == "httpipfs" {
 		if _, err := setup.IPFS(setup.Options{
@@ -157,7 +172,7 @@ func handleInit(ctx *cli.Context) error {
 			Setup:            doIpfsSetup,
 			SetDefaultConfig: doIpfsConfig,
 			SetExtraConfig:   doExtraIpfsConfig,
-			IpfsPath:         ipfsPath,
+			IpfsPath:         ipfsRepoPath,
 		}); err != nil {
 			return err
 		}
@@ -170,7 +185,7 @@ func handleInit(ctx *cli.Context) error {
 
 	if err := Init(
 		ctx,
-		ipfsPath,
+		ipfsPathOrURL,
 		repo.InitOptions{
 			BaseFolder:  folder,
 			Owner:       owner,
@@ -401,7 +416,7 @@ func handleDaemonLaunch(ctx *cli.Context) error {
 	if err != nil {
 		log.Warningf("failed to read config at %v: %v", repoPath, err)
 	} else {
-		ipfsPath = cfg.String("daemon.ipfs_path")
+		ipfsPath = cfg.String("daemon.ipfs_path_or_url")
 	}
 
 	if _, err := setup.IPFS(setup.Options{

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -85,7 +85,7 @@ func guessRepoFolder(ctx *cli.Context) (string, error) {
 	var lastError error
 	for _, guessLocation := range guessLocations {
 		repoFolder := mustAbsPath(guessLocation)
-		if _, err := os.Stat(filepath.Join(repoFolder, "OWNER")); err != nil {
+		if _, err := os.Stat(filepath.Join(repoFolder, "config.yml")); err != nil {
 			lastError = err
 			continue
 		}
@@ -242,7 +242,7 @@ func startDaemon(ctx *cli.Context, repoPath, daemonURL string) (*client.Client, 
 		return ctl, nil
 	}
 
-	return nil, fmt.Errorf("Daemon could not be started or took to long. Wrong password maybe?")
+	return nil, fmt.Errorf("Daemon could not be started or took to long.")
 }
 
 func isDaemonRunning(ctx *cli.Context) (bool, error) {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -242,7 +242,7 @@ func startDaemon(ctx *cli.Context, repoPath, daemonURL string) (*client.Client, 
 		return ctl, nil
 	}
 
-	return nil, fmt.Errorf("Daemon could not be started or took to long.")
+	return nil, fmt.Errorf("Daemon could not be started or took to long")
 }
 
 func isDaemonRunning(ctx *cli.Context) (bool, error) {

--- a/defaults/defaults_v0.go
+++ b/defaults/defaults_v0.go
@@ -44,10 +44,10 @@ var DefaultsV0 = config.DefaultMapping{
 			Docs:         "URL of the daemon process.",
 			Validator:    urlValidator,
 		},
-		"ipfs_path": config.DefaultEntry{
+		"ipfs_path_or_url": config.DefaultEntry{
 			Default:      "",
 			NeedsRestart: true,
-			Docs:         "Path to the IPFS repository you want to use.",
+			Docs:         "URL or path to the IPFS repository you want to use.",
 		},
 		"enable_pprof": config.DefaultEntry{
 			Default:      true,

--- a/fuse/fusetest/helper.go
+++ b/fuse/fusetest/helper.go
@@ -27,7 +27,7 @@ func LaunchAsProcess(opts Options) (*os.Process, error) {
 		"fusemock",
 		"--mount-path", opts.MountPath,
 		"--catfs-path", opts.CatfsPath,
-		"--ipfs-path-or-url", opts.IpfsPathOrURL,
+		"--ipfs-path-or-multiaddr", opts.IpfsPathOrMultiaddr,
 		"--url", opts.URL,
 	}
 

--- a/fuse/fusetest/helper.go
+++ b/fuse/fusetest/helper.go
@@ -27,7 +27,7 @@ func LaunchAsProcess(opts Options) (*os.Process, error) {
 		"fusemock",
 		"--mount-path", opts.MountPath,
 		"--catfs-path", opts.CatfsPath,
-		"--ipfs-path", opts.IpfsPath,
+		"--ipfs-path-or-url", opts.IpfsPathOrURL,
 		"--url", opts.URL,
 	}
 

--- a/fuse/fusetest/server.go
+++ b/fuse/fusetest/server.go
@@ -122,7 +122,7 @@ type Options struct {
 
 	// IpfsPath tells us which IPFS repo to use.
 	// If empty, use the mock backend.
-	IpfsPathOrURL string
+	IpfsPathOrMultiaddr string
 
 	// URL defines where the server can be reached.
 	URL string
@@ -150,8 +150,8 @@ func Launch(opts Options) error {
 	}
 
 	var backend catfs.FsBackend
-	if opts.IpfsPathOrURL != "" {
-		backend, err = httpipfs.NewNode(opts.IpfsPathOrURL, "")
+	if opts.IpfsPathOrMultiaddr != "" {
+		backend, err = httpipfs.NewNode(opts.IpfsPathOrMultiaddr, "")
 	} else {
 		backend = catfs.NewMemFsBackend()
 	}

--- a/fuse/fusetest/server.go
+++ b/fuse/fusetest/server.go
@@ -122,7 +122,7 @@ type Options struct {
 
 	// IpfsPath tells us which IPFS repo to use.
 	// If empty, use the mock backend.
-	IpfsPath string
+	IpfsPathOrURL string
 
 	// URL defines where the server can be reached.
 	URL string
@@ -150,8 +150,8 @@ func Launch(opts Options) error {
 	}
 
 	var backend catfs.FsBackend
-	if opts.IpfsPath != "" {
-		backend, err = httpipfs.NewNode(opts.IpfsPath, "")
+	if opts.IpfsPathOrURL != "" {
+		backend, err = httpipfs.NewNode(opts.IpfsPathOrURL, "")
 	} else {
 		backend = catfs.NewMemFsBackend()
 	}

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mr-tron/base58 v1.2.0
-	github.com/multiformats/go-multiaddr v0.3.1 // indirect
+	github.com/multiformats/go-multiaddr v0.3.1
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/nbutton23/zxcvbn-go v0.0.0-20201221231540-e56b841a3c88
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/repo/setup/ipfs.go
+++ b/repo/setup/ipfs.go
@@ -70,21 +70,21 @@ func getAPIAddrFromConfig(baseDir string) (ma.Multiaddr, error) {
 }
 
 // GetAPIAddrForPath returns the API addr of the IPFS repo at `baseDir`.
-func GetAPIAddrForPath(ipfsPathOrURL string) (ma.Multiaddr, error) {
-	m, err := ma.NewMultiaddr(ipfsPathOrURL)
+func GetAPIAddrForPath(ipfsPathOrMultiaddr string) (ma.Multiaddr, error) {
+	m, err := ma.NewMultiaddr(ipfsPathOrMultiaddr)
 	if err == nil {
 		return m, nil
 	}
 
 	// assume it's a path:
-	apiFile := filepath.Join(ipfsPathOrURL, defaultAPIFile)
+	apiFile := filepath.Join(ipfsPathOrMultiaddr, defaultAPIFile)
 	if _, err := os.Stat(apiFile); err != nil {
-		return getAPIAddrFromConfig(ipfsPathOrURL)
+		return getAPIAddrFromConfig(ipfsPathOrMultiaddr)
 	}
 
 	apiAddr, err := ioutil.ReadFile(apiFile)
 	if err != nil {
-		return getAPIAddrFromConfig(ipfsPathOrURL)
+		return getAPIAddrFromConfig(ipfsPathOrMultiaddr)
 	}
 
 	s := strings.TrimSpace(string(apiAddr))

--- a/scripts/test-bed.sh
+++ b/scripts/test-bed.sh
@@ -35,8 +35,8 @@ brig_bob() {
     fi
 }
 
-brig_ali init ali --ipfs-path /tmp/ali-ipfs
-brig_bob init bob --ipfs-path /tmp/bob-ipfs
+brig_ali init ali --ipfs-path-or-url /tmp/ali-ipfs
+brig_bob init bob --ipfs-path-or-url /tmp/bob-ipfs
 
 # Add them as remotes each
 if [ "$USE_SINGLE" = false ]; then

--- a/scripts/test-bed.sh
+++ b/scripts/test-bed.sh
@@ -35,8 +35,8 @@ brig_bob() {
     fi
 }
 
-brig_ali init ali --ipfs-path-or-url /tmp/ali-ipfs
-brig_bob init bob --ipfs-path-or-url /tmp/bob-ipfs
+brig_ali init ali --ipfs-path-or-multiaddr /tmp/ali-ipfs
+brig_bob init bob --ipfs-path-or-multiaddr /tmp/bob-ipfs
 
 # Add them as remotes each
 if [ "$USE_SINGLE" = false ]; then

--- a/server/base.go
+++ b/server/base.go
@@ -67,13 +67,13 @@ type base struct {
 }
 
 func repoIsInitialized(path string) error {
-	data, err := ioutil.ReadFile(filepath.Join(path, "OWNER")) // #nosec
+	data, err := ioutil.ReadFile(filepath.Join(path, "config.yml")) // #nosec
 	if err != nil {
 		return err
 	}
 
 	if len(data) == 0 {
-		return fmt.Errorf("OWNER is empty")
+		return fmt.Errorf("no config.yml")
 	}
 
 	return nil
@@ -181,7 +181,7 @@ func (b *base) loadBackend() error {
 
 	realBackend, err := backend.FromName(
 		backendName,
-		b.repo.Config.String("daemon.ipfs_path"),
+		b.repo.Config.String("daemon.ipfs_path_or_url"),
 		fingerprint.PubKeyID(),
 	)
 

--- a/server/repo_handler.go
+++ b/server/repo_handler.go
@@ -334,7 +334,7 @@ func (rh *repoHandler) Version(call capnp.Repo_version) error {
 
 	rp := rh.base.repo
 	name := rp.Immutables.Backend()
-	ipfsPath := rp.Config.String("daemon.ipfs_path")
+	ipfsPath := rp.Config.String("daemon.ipfs_path_or_url")
 	bkVersion := backend.Version(name, ipfsPath)
 	if bkVersion == nil {
 		return fmt.Errorf("bug: invalid backend name: %v", name)


### PR DESCRIPTION
This closes #32. We now allow the following form of ``brig init``:

```bash
brig init --repo . --ipfs-path-or-url /ip4/127.0.0.1/tcp/5002 some-name
```

This will connect to an existing IPFS daemon at the specified mutliaddr.