### PR TITLE
Readme: Update development build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,24 +44,25 @@ Also take a look [at the documentation](http://brig.readthedocs.io/en/latest/ind
 
 ## Installation
 
-You can download the latest script with the following oneliner:
+You can use the installer script with the following oneliner:
 
 ```bash
 # Before you execute this, ask yourself if you trust me.
 $ bash <(curl -s https://raw.githubusercontent.com/sahib/brig/master/scripts/install.sh)
 ```
 
-Alternatively, you can simply grab the latest binary from the [release tab](https://github.com/sahib/brig/releases).
+Alternatively, you can simply grab the **latest binary** from the [release tab](https://github.com/sahib/brig/releases).
 
-Development versions can be installed easily by compiling yourself. If you have
-a recent version of `go` (`>= 1.10`) installed, it should be as easy as this:
+**Development versions** can be installed easily by compiling yourself.
+Requirements:
+- `bash` (in PATH, doesn't have to be your shell of choice)
+- a recent version of `go` (`>= 1.10`)
+- [taskfile](https://taskfile.dev/#/installation)
 
 ```bash
-$ go get -d -v -u github.com/sahib/brig  # Download the sources.
-$ cd $GOPATH/src/github.com/sahib/brig   # Go to the source directory.
-$ git checkout develop                   # Checkout the develop branch.
-$ go run mage.go                         # Build the software.
-$ $GOPATH/bin/brig help                  # Run the binary.
+git clone https://github.com/sahib/brig  # Download the sources.
+task build                               # run build task
+$GOPATH/bin/brig help                    # Run the binary.
 ```
 
 Please refer to the [install docs](https://brig.readthedocs.io/en/latest/installation.html) for more details.


### PR DESCRIPTION
For my issue reports I was asked if the error is still happening in develop binary, so I tried to figure out how to build it (as the instructions were outdated).

I managed to compile using the given instructions, so I guess this PR could be merged, but I'm not sure as the built binary is giving me trouble:

### brig path not detected
I need to set BRIG_PATH environment variable, otherwise the daemon wont launch, as it only checks for config.yml in current working dir.
I guess there's a [TODO related](https://github.com/sahib/brig/blob/6b7eccf8fcbd907fc759f8ca8aa814df8499e2ed/cmd/util.go#L81) ?

### brig repo of latest stable cannot be used
I get error of missing `immutable.yml` - I guess there is no migration process yet?
So I delete repo and `init` again, but...

### ipfs dir is not detected or set
It again tries to search for IPFS files (`config` dir I think) in current working dir, but I found I could set it manually in config.yml:
`ipfs_path_or_url: "/home/manu/.ipfs"`